### PR TITLE
Add hashing and hash verification

### DIFF
--- a/docs/Scrypt.html
+++ b/docs/Scrypt.html
@@ -78,6 +78,28 @@ Same as <a href="Scrypt.html#VALencrypt"><code class="code">Scrypt.encrypt</code
 <pre><span id="VALdecrypt_exn"><span class="keyword">val</span> decrypt_exn</span> : <code class="type">?maxmem:int -><br>       ?maxmemfrac:float -> ?maxtime:float -> string -> string -> string</code></pre><div class="info ">
 Same as <a href="Scrypt.html#VALdecrypt"><code class="code">Scrypt.decrypt</code></a> except raise <a href="Scrypt.html#EXCEPTIONScrypt_error"><code class="code">Scrypt.Scrypt_error</code></a> in case of an error.<br>
 </div>
+
+<pre><span id="VALhash"><span class="keyword">val</span> hash</span> : <code class="type">?logN:int -> ?r:int -> ?p:int -> string -> string option</code></pre><div class="info ">
+<code class="code">hash passwd</code> hashes <code class="code">passwd</code> and returns a derived key <code class="code">Some string</code> or <code class="code">None</code> if there was an error.
+<p>
+
+    Optional parameters:
+    <ul>
+<li><code class="code">logN</code> Base-2 logarithm of the general work factor. Defaults to 14, which is fine for interactive use. Increase <code class="code">logN</code> for sensitive or offline storage. However, N is an int64, so inputs &gt;= 64  or &lt; 0 are unspecified. </li>
+<li><code class="code">r</code> Blocksize of the underlying hash. Fine-tunes the relative memory cost. Defaults to <code class="code">8</code>. </li>
+<li><code class="code">p</code> Parallelization factor. Fine-tunes the relative CPU cost. Defaults to <code class="code">1</code>. </li>
+</ul>
+
+    The parameters <code class="code">r</code> and <code class="code">p</code> must satisfy <code class="code">r * p &lt; 2^30</code>.<br>
+</div>
+
+<pre><span id="VALhash_exn"><span class="keyword">val</span> hash_exn</span> : <code class="type">?logN:int -> ?r:int -> ?p:int -> string -> string</code></pre><div class="info ">
+Same as <a href="Scrypt.html#VALhash"><code class="code">Scrypt.hash</code></a> except raise <a href="Scrypt.html#EXCEPTIONScrypt_error"><code class="code">Scrypt.Scrypt_error</code></a> in case of an error.<br>
+</div>
+
+<pre><span id="VALverify"><span class="keyword">val</span> verify</span> : <code class="type">string -> string -> bool</code></pre><div class="info ">
+<code class="code">verify passwd scrypt_str</code> compares the password <code class="code">passwd</code> against a string <code class="code">scrypt_str</code> that is encoded with the scrypt parameters, such as the one returned by <a href="Scrypt.html#VALhash"><code class="code">Scrypt.hash</code></a>. Returns true if the comparison succeeds, false otherwise.<br>
+</div>
 <br>
 <h1 id="scrypt_params">Meaning of <code class="code">maxmem</code>, <code class="code">maxmemfrac</code>, and <code class="code">maxtime</code></h1>
 <p>

--- a/docs/index_values.html
+++ b/docs/index_values.html
@@ -35,6 +35,23 @@ Same as <a href="Scrypt.html#VALdecrypt"><code class="code">Scrypt.decrypt</code
 Same as <a href="Scrypt.html#VALencrypt"><code class="code">Scrypt.encrypt</code></a> except raise <a href="Scrypt.html#EXCEPTIONScrypt_error"><code class="code">Scrypt.Scrypt_error</code></a> in case of an error.
 </div>
 </td></tr>
+<tr><td align="left"><br>H</td></tr>
+<tr><td><a href="Scrypt.html#VALhash">hash</a> [<a href="Scrypt.html">Scrypt</a>]</td>
+<td><div class="info">
+<code class="code">hash passwd</code> hashes <code class="code">passwd</code> and returns a derived key <code class="code">Some string</code> or <code class="code">None</code> if there was an error.
+</div>
+</td></tr>
+<tr><td><a href="Scrypt.html#VALhash_exn">hash_exn</a> [<a href="Scrypt.html">Scrypt</a>]</td>
+<td><div class="info">
+Same as <a href="Scrypt.html#VALhash"><code class="code">Scrypt.hash</code></a> except raise <a href="Scrypt.html#EXCEPTIONScrypt_error"><code class="code">Scrypt.Scrypt_error</code></a> in case of an error.
+</div>
+</td></tr>
+<tr><td align="left"><br>V</td></tr>
+<tr><td><a href="Scrypt.html#VALverify">verify</a> [<a href="Scrypt.html">Scrypt</a>]</td>
+<td><div class="info">
+<code class="code">verify passwd scrypt_str</code> compares the password <code class="code">passwd</code> against a string <code class="code">scrypt_str</code> that is encoded with the scrypt parameters, such as the one returned by <a href="Scrypt.html#VALhash"><code class="code">Scrypt.hash</code></a>.
+</div>
+</td></tr>
 </table>
 </body>
 </html>

--- a/docs/type_Scrypt.html
+++ b/docs/type_Scrypt.html
@@ -22,4 +22,7 @@
 &nbsp;&nbsp;<span class="keyword">val</span>&nbsp;decrypt_exn&nbsp;:<br>
 &nbsp;&nbsp;&nbsp;&nbsp;?maxmem:int&nbsp;<span class="keywordsign">-&gt;</span><br>
 &nbsp;&nbsp;&nbsp;&nbsp;?maxmemfrac:float&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;?maxtime:float&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;string&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;string&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;string<br>
+&nbsp;&nbsp;<span class="keyword">val</span>&nbsp;hash&nbsp;:&nbsp;?logN:int&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;?r:int&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;?p:int&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;string&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;string&nbsp;option<br>
+&nbsp;&nbsp;<span class="keyword">val</span>&nbsp;hash_exn&nbsp;:&nbsp;?logN:int&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;?r:int&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;?p:int&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;string&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;string<br>
+&nbsp;&nbsp;<span class="keyword">val</span>&nbsp;verify&nbsp;:&nbsp;string&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;string&nbsp;<span class="keywordsign">-&gt;</span>&nbsp;bool<br>
 <span class="keyword">end</span></code></body></html>

--- a/scrypt.ml
+++ b/scrypt.ml
@@ -3,6 +3,8 @@ let _ = Callback.register_exception "Scrypt_error" (Scrypt_error 0)
 
 external scryptenc_buf : string -> string -> int -> float -> float -> string = "scryptenc_buf_stub"
 external scryptdec_buf : string -> string -> int -> float -> float -> string = "scryptdec_buf_stub"
+external crypto_scrypt : string -> string -> int64 -> int -> int -> string ->
+  unit = "crypto_scrypt_bytecode" "crypto_scrypt_native"
 
 (* Default values for optional arguments are chosen to match the scrypt command line utility. *)
 
@@ -18,4 +20,53 @@ let decrypt_exn ?(maxmem=0) ?(maxmemfrac=0.5) ?(maxtime=300.0) cyphertext passwd
 
 let decrypt ?(maxmem=0) ?(maxmemfrac=0.5) ?(maxtime=300.0) cyphertext passwd =
   try Some (decrypt_exn ~maxmem ~maxmemfrac ~maxtime cyphertext passwd)
+  with Scrypt_error _ -> None
+
+(* one day re-implement these to avoid int32 boxing; it is unnecessary here *)
+(* given that the values we're setting/getting fit within a tagged int *)
+external w32 : Bytes.t -> int -> int32 -> unit = "%caml_string_set32"
+external swap32 : int32 -> int32 = "%bswap_int32"
+
+external sha256 : Bytes.t -> String.t = "scrypt_sha256"
+external hmac_sha256 : Bytes.t -> Bytes.t -> String.t = "scrypt_hmac_sha256"
+
+let be32enc s off v =
+  if Sys.big_endian
+  then w32 s off v
+  else w32 s off (swap32 v)
+
+let hash_exn ?(logN=14) ?(r=8) ?(p=1) passwd =
+  (* Prepare inputs to KDF *)
+  let salt = String.init 32 (fun _ -> Char.chr (Random.int 256)) in
+  let dk = Bytes.create 64 in
+  let n = Int64.shift_left 1L logN in
+
+  (* Generate the derived keys. *)
+  crypto_scrypt passwd salt n r p dk;
+
+  (* Create output string. *)
+  let out = Bytes.create 96 in
+
+  (* Blit header values into output string. *)
+  Bytes.blit_string "scrypt\000" 0 out 0 7;
+  let () = try
+    Bytes.set out 7 (Char.chr logN)
+  with _ -> raise (Scrypt_error (-1)) in
+  be32enc out 8 (Int32.of_int r);
+  be32enc out 12 (Int32.of_int p);
+  Bytes.blit_string salt 0 out 16 32;
+
+  (* Construct the header checksum. *)
+  let checksum = sha256 (Bytes.sub out 0 48) in
+  Bytes.blit_string checksum 0 out 48 16;
+
+  (* Add header signature (used for verifying password). *)
+  let signature = hmac_sha256 (Bytes.sub out 0 64) (Bytes.sub dk 32 32) in
+  Bytes.blit_string signature 0 out 64 32;
+
+  (* All done! *)
+  Bytes.unsafe_to_string out
+
+let hash ?logN ?r ?p passwd =
+  try Some (hash_exn ?logN ?r ?p passwd)
   with Scrypt_error _ -> None

--- a/scrypt.mli
+++ b/scrypt.mli
@@ -47,6 +47,21 @@ val decrypt : ?maxmem:int -> ?maxmemfrac:float -> ?maxtime:float -> string -> st
 (** Same as {!decrypt} except raise {!Scrypt_error} in case of an error. *)
 val decrypt_exn : ?maxmem:int -> ?maxmemfrac:float -> ?maxtime:float -> string -> string -> string
 
+(** [hash passwd] hashes [passwd] and returns a derived key [Some string] or [None] if there was an error.
+
+    Optional parameters:
+    {ul
+      {li [logN] Base-2 logarithm of the general work factor. Defaults to 14, which is fine for interactive use. Increase [logN] for sensitive or offline storage. However, N is an int64, so inputs >= 64  or < 0 are unspecified. }
+      {li [r] Blocksize of the underlying hash. Fine-tunes the relative memory cost. Defaults to [8]. }
+      {li [p] Parallelization factor. Fine-tunes the relative CPU cost. Defaults to [1]. }
+    }
+    The parameters [r] and [p] must satisfy [r * p < 2^30].
+*)
+val hash : ?logN:int -> ?r:int -> ?p:int -> string -> string option
+
+(** Same as {!hash} except raise {!Scrypt_error} in case of an error. *)
+val hash_exn : ?logN:int -> ?r:int -> ?p:int -> string -> string
+
 (** {1:scrypt_params Meaning of [maxmem], [maxmemfrac], and [maxtime]}
 
     {ul

--- a/scrypt.mli
+++ b/scrypt.mli
@@ -62,6 +62,10 @@ val hash : ?logN:int -> ?r:int -> ?p:int -> string -> string option
 (** Same as {!hash} except raise {!Scrypt_error} in case of an error. *)
 val hash_exn : ?logN:int -> ?r:int -> ?p:int -> string -> string
 
+(** [verify passwd scrypt_str] compares the plaintext password [passwd] against a derived key [scrypt_str] such as the one returned by {!hash}. Returns true if the comparison succeeds, false otherwise.
+*)
+val verify : string -> string -> bool
+
 (** {1:scrypt_params Meaning of [maxmem], [maxmemfrac], and [maxtime]}
 
     {ul

--- a/scrypt_stubs.c
+++ b/scrypt_stubs.c
@@ -8,6 +8,11 @@
 #include <caml/fail.h>
 #include "scrypt.h"
 
+// for hashing
+#include "scrypt-1.1.6/lib/crypto/crypto_scrypt.h"
+#include <openssl/sha.h>
+#include <openssl/hmac.h>
+
 #define SCRYPT_MALLOC_ERROR 6
 
 #define check_mem(A) if(!A) { goto error; }
@@ -136,4 +141,80 @@ error:
 
 	scrypt_raise_scrypt_error(err);
 	CAMLreturn(decrypted_data);
+}
+
+CAMLprim value crypto_scrypt_native(value passwd, value salt, value N, value r, value p, value buf) {
+    CAMLparam5(passwd, salt, N, r, p);
+    CAMLxparam1(buf);
+    const uint8_t* pwd_p = &Byte_u(passwd, 0);
+    const uint8_t* slt_p = &Byte_u(salt, 0);
+    uint8_t* buf_p = &Byte_u(buf, 0);
+
+    int pwdlen = caml_string_length(passwd);
+    int sltlen = caml_string_length(salt);
+    int buflen = caml_string_length(buf);
+
+    int64 N_p = Int64_val(N);
+    int r_p = Val_int(r);
+    int p_p = Val_int(p);
+
+    int err = crypto_scrypt(pwd_p, pwdlen, slt_p, sltlen, N_p, r_p, p_p, buf_p, buflen);
+    check_err(err);
+
+    CAMLreturn(Val_unit);
+
+error:
+    scrypt_raise_scrypt_error(err);
+    CAMLreturn(Val_unit);
+}
+
+CAMLprim value crypto_scrypt_bytecode(value *argv, int argc)
+{
+    return crypto_scrypt_native(argv[0], argv[1], argv[2], argv[3], argv[4], argv[5]);
+}
+
+CAMLprim value scrypt_sha256(value str)
+{
+    CAMLparam1(str);
+    CAMLlocal1(digest);
+
+    uint8_t *sbuf, *dbuf;
+    int slen;
+    SHA256_CTX ctx;
+
+    digest = caml_alloc_string(32);
+    slen = caml_string_length(str);
+    sbuf = &Byte_u(str, 0);
+    dbuf = &Byte_u(digest, 0);
+
+    /* Add header checksum. */
+    SHA256_Init(&ctx);
+    SHA256_Update(&ctx, sbuf, slen);
+    SHA256_Final(dbuf, &ctx);
+
+    CAMLreturn(digest);
+}
+
+CAMLprim value scrypt_hmac_sha256(value data, value key)
+{
+    CAMLparam2(data, key);
+    CAMLlocal1(hmac);
+
+    uint8_t *dbuf, *kbuf, *hbuf;
+    int datalen, keylen;
+    HMAC_CTX ctx;
+
+    hmac = caml_alloc_string(32);
+    datalen = caml_string_length(data);
+    keylen = caml_string_length(key);
+    kbuf = &Byte_u(key, 0);
+    hbuf = &Byte_u(hmac, 0);
+    dbuf = &Byte_u(data, 0);
+
+    /* Add header signature. (used for verifying password). */
+    HMAC_Init(&ctx, kbuf, keylen, EVP_sha256());
+    HMAC_Update(&ctx, dbuf, datalen);
+    HMAC_Final(&ctx, hbuf, NULL);
+
+    CAMLreturn(hmac);
 }


### PR DESCRIPTION
Useful for password storage, etc.

The use of crypto_scrypt follows the guidelines in https://github.com/Tarsnap/scrypt/commit/ccb623b6d6aed12f48eb1ba1bd4e399ca995dfa6.

The header structure and verification code is a (mostly) OCaml re-implementation of the existing C in scrypenc_setup and scryptdec_setup -- The header is necessary to store the parameters used for the initial key derivation, so validation can occur using the same parameters. SHA256 and HMAC-SHA256 are OpenSSL's implementations, called through the FFI since OpenSSL is already a dependency for scrypt-1.1.6.
