### PR TITLE
FIX Get compiling on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $(SCRYPT_LIB):
 	# Compile scrypt, but immediately explode the library into it's object files.
 	# We do this to merge the objects with scrypt_stubs.o into a new, unified, library under the name libscrypt.a
 	# The merging step happens during ocamlmklib linking.
-	cd libscrypt && make && ar x libscrypt.a
+	cd libscrypt && $(MAKE) && ar -x libscrypt.a
 
 install:
 	ocamlfind install scrypt META *.cmi *.cmxa *.cma *.a *.so
@@ -68,4 +68,4 @@ docs:
 clean:
 	rm -f *.cmi *.cmxa *.cma *.cmx *.cmo *.o *.so *.a
 	rm -f libscrypt/*.o libscrypt/__.SYMDEF*
-	cd libscrypt && make clean
+	cd libscrypt && $(MAKE) clean

--- a/libscrypt/Makefile
+++ b/libscrypt/Makefile
@@ -25,13 +25,13 @@ $(CONFIG_H):
 	cd $(SCRYPT) && ./configure
 
 libscrypt.a: $(CONFIG_H) $(OBJECTS)
-	ar rcs $@ $(OBJECTS)
+	ar -rcs $@ $(OBJECTS)
 	ranlib $@
 
 libscrypt.so: $(CONFIG_H) $(OBJECTS)
 	$(CC) $(CFLAGS) -shared -o $@ $(OBJECTS)
 
 clean:
-	cd $(SCRYPT) && make clean && rm -rf .deps Makefile config.h config.log config.status stamp-h1
+	cd $(SCRYPT) && $(MAKE) clean && rm -rf .deps Makefile config.h config.log config.status stamp-h1
 	rm -f libscrypt.a libscrypt.so scrypt.h
 	rm -rf $(OBJECTS)


### PR DESCRIPTION
I'm not sure if these changes break on linux/mac, but `ar` requires the dash on FreeBSD.

If these do not work for Linux/Mac, maybe the commit should become a patch applied on FreeBSD?